### PR TITLE
Path Size Enforcement Prompt and Ignore 2 Words or Less Check For Generated Paths

### DIFF
--- a/prompts/prompts_en.py
+++ b/prompts/prompts_en.py
@@ -169,7 +169,26 @@ prompts_en = {
     The response should be in the following format:
     shortened_text
     The response should be just the shortened text without quotation marks, line breaks or anything else.
-  """,
+    """,
+    'PATH_SIZE_ENFORCEMENT': """
+    I will give you a list of Responsive Search Ads display path texts for Google Ads that may be too long,
+    from a list of paths, each individually called a part.  The path should be in the format of
+    ["part 1 of the path", "part 2 of the path"], and it is possible for only one part to exist or
+    the path being empty (which are valid cases).
+
+    Check each part.  Make the part shorter if the part is less than {max_length} characters, and check all parts.
+    If a part does not need shortening, then keep the same part on the list.
+    The text is: {copy}
+
+    Give me the result in the following format (the same format as the text):
+    ["write part 1 of the path here", "write part 2 of the path here"]
+    The answer must be given to me exactly in the format that I have given you, without adding
+    unnecessary line breaks or spaces. It should only be a list of texts separated by commas,
+    everything between brackets and nothing else.
+
+    IMPORTANT: It should NOT contain capital letters or spaces, if there are several words they should
+    be in lowercase and separated by a hyphen.
+    """,
     "EXTRACT_MAIN_FEATURES": """
     Given the following product description:
     '{description}'

--- a/prompts/prompts_es.py
+++ b/prompts/prompts_es.py
@@ -142,6 +142,25 @@ prompts_es = {
                         texto_acortado
                         Solamente escribe como respuesta el texto acortado, sin comillas, saltos de linea ni nada adicional.
                         """,
+    'PATH_SIZE_ENFORCEMENT': """
+    Te daré una lista de textos de rutas de visualización de anuncios de búsqueda responsivos para Google Ads que pueden ser demasiado largos,
+    de una lista de rutas, cada una de las cuales se denomina individualmente una parte. La ruta debe tener el formato de
+    ["parte 1 de la ruta", "parte 2 de la ruta"], y es posible que solo exista una parte o
+    que la ruta esté vacía (que son casos válidos).
+
+    Comprueba cada parte. Acorta la parte si tiene menos de {max_length} caracteres y comprueba todas las partes.
+    Si una parte no necesita acortarse, mantén la misma parte en la lista.
+    El texto es: {copy}
+
+    Dame el resultado en el siguiente formato (el mismo formato que el texto):
+    ["escribe la parte 1 de la ruta aquí", "escribe la parte 2 de la ruta aquí"]
+    La respuesta debe ser dada exactamente en el formato que te he dado, sin agregar
+    saltos de línea innecesarios ni espacios. Solo debe ser una lista de textos separados por comas,
+    todo entre corchetes y nada más.
+
+    IMPORTANTE: NO debe contener mayúsculas ni espacios, si son varias palabras deben
+    ir en minúsculas y separadas por un guion.
+    """,
     'EXTRACT_MAIN_FEATURES': """
         Dada la siguiente descripcion de producto:
         "{description}"

--- a/services/content_generator_service.py
+++ b/services/content_generator_service.py
@@ -586,6 +586,7 @@ class ContentGeneratorService:
         self.entries.remove(self.entries[i])
         self.entries[i].clear_generated_content()
         self.entries.append(self.entries[i])
+
       else:
         self.bar()
         i = i + 1
@@ -863,10 +864,11 @@ class ContentGeneratorService:
         )
 
     # Remove copies that are 2 words or less
-    for copy in generated_copies_with_size_enforced:
-      copy_splitted = copy.split(' ')
-      if len(copy_splitted) <= 2:
-        generated_copies_with_size_enforced.remove(copy)
+    if t != 'paths':
+      for copy in generated_copies_with_size_enforced:
+        copy_splitted = copy.split(' ')
+        if len(copy_splitted) <= 2:
+          generated_copies_with_size_enforced.remove(copy)
 
     # If retries still available and not enough copies, generate more
     if (


### PR DESCRIPTION
Adding PATH_SIZE_ENFORCEMENT prompts into English and Spanish version of the prompts and removes the 2 words or less check when creating paths (the check removes words in the given list if there are 2 words or less in the list).